### PR TITLE
courses-container fix in sortAllByGPA

### DIFF
--- a/terp.course.helper.user.js
+++ b/terp.course.helper.user.js
@@ -319,7 +319,7 @@ function main() {
 }
 
 function sortAllByGPA() {
-  const coursesContainer = document.querySelector('#courses-page');
+  const coursesContainer = document.querySelector('.courses-container');
   const allCourses = [...document.querySelectorAll('div.course')];
 
   allCourses.sort((courseElem, otherCourseElem) => {


### PR DESCRIPTION
replace #courses-page with .courses-container in order to maintain the default hierarchical div layout of the page